### PR TITLE
Load fonts from Google CDN with SSL

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -12,11 +12,11 @@
     <![endif]-->
 
     <!-- Le styles -->
+    <link href="https://fonts.googleapis.com/css?family=Gudea:400,400italic|Alegreya+SC" rel="stylesheet" type="text/css">
     <link href="//netdna.bootstrapcdn.com/twitter-bootstrap/2.1.1/css/bootstrap.no-icons.min.css" rel="stylesheet">
     <link href="{{ SITEURL }}/theme/local.css" rel="stylesheet">
     <link href="{{ SITEURL }}/theme/pygments.css" rel="stylesheet">
     <link href="{{ SITEURL }}/theme/font-awesome.css" rel="stylesheet">
-    <link href='http://fonts.googleapis.com/css?family=Gudea:400,400italic|Alegreya+SC' rel='stylesheet' type='text/css'>
 </head>
 
 <body>

--- a/templates/base.html
+++ b/templates/base.html
@@ -16,7 +16,7 @@
     <link href="{{ SITEURL }}/theme/local.css" rel="stylesheet">
     <link href="{{ SITEURL }}/theme/pygments.css" rel="stylesheet">
     <link href="{{ SITEURL }}/theme/font-awesome.css" rel="stylesheet">
-    <link href='http://fonts.googleapis.com/css?family=Gudea:400,400italic|Alegreya+SC' rel='stylesheet' type='text/css'>
+    <link href="https://fonts.googleapis.com/css?family=Gudea:400,400italic|Alegreya+SC" rel="styleshee" type="text/css">
 </head>
 
 <body>


### PR DESCRIPTION
This allows for loading the resource when serving the blog over HTTPS.
